### PR TITLE
Packages Readme added

### DIFF
--- a/src/Svenkle.NuGetServer.Website/Packages/Readme.txt
+++ b/src/Svenkle.NuGetServer.Website/Packages/Readme.txt
@@ -1,0 +1,2 @@
+﻿To add packages to the feed put package files (.nupkg files) in this folder.
+NuGet Server will automatically copy the package to the correct location.


### PR DESCRIPTION
Cannot build service if Packages/README.txt does not exist.